### PR TITLE
SCAUT-366: Add playbooks to manage SSH users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ OpenShift.
 - [lock-down-sshd.yml](playbooks/lock-down-sshd.yml) will adjust the SSH setup to comply better with [securing CentOS SSH](https://wiki.centos.org/HowTos/Network/SecuringSSH). 
 - [add-users.yml](playbooks/add-users.yml) will create user accounts on all hosts in the inventory, and install an SSH authorized key.
 - [remove-users.yml](playbooks/remove-users.yml) will remove user accounts on all hosts in the inventory.
+- [set-passwords.yml](playbooks/rset-passwords.yml) will set passwords on user accounts on all hosts in the inventory.
 
 An example execution of the user playbooks is:
 
 - `ansible-playbook playbooks/add-users.yml --extra-vars=users='[{"name":"bob","group":"cluster_admin","is_admin":true,"key":"/home/myuser/bob.pub"}]'`
 - `ansible-playbook playbooks/remove-users.yml --extra-vars=users='[{"name":"bob"}]'`
+- `ansible-playbook playbooks/set-passwords.yml --extra-vars=users='[{"name":"bob","password":"secretSauce1"}]'`
 
 Note: Be careful with `playbooks/lock-down-sshd.yml`! It will change the SSH port, prevent logins as root and other things. 
 Make sure you understand what it does, and that you don't accidentally lock yourself out of the system. 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,20 @@ Some nice-to-have playbooks for CentOS7 and OpenShift together, especially when 
 via [openshift/openshift-ansible](https://github.com/openshift/openshift-ansible). 
 Includes a testbed using Vagrant for faster iteration on playbook changes.
 
-There are 3 playbooks of note:
+There are 5 playbooks of note:
 
-- `playbooks/prep-server.yml` updates yum, and installs NetworkManager, git, vim, pip. It then starts NetworkManager as 
+- [prep-server.yml](playbooks/prep-server.yml) updates yum, and installs NetworkManager, git, vim, pip. It then starts NetworkManager as 
 a service, and ensures that `SELINUX=enforcing` in `/etc/selinux/config`, complying with software needed prior to installing 
 OpenShift.
-- `playbooks/docker.yml` will replace the default CentOS 7 Docker with Docker-CE, and use `overlay2` as a storage-driver for it.
-- `playbooks/lock-down-sshd.yml` will adjust the SSH setup to comply better with [securing CentOS SSH](https://wiki.centos.org/HowTos/Network/SecuringSSH). 
+- [docker.yml](playbooks/docker.yml) will replace the default CentOS 7 Docker with Docker-CE, and use `overlay2` as a storage-driver for it.
+- [lock-down-sshd.yml](playbooks/lock-down-sshd.yml) will adjust the SSH setup to comply better with [securing CentOS SSH](https://wiki.centos.org/HowTos/Network/SecuringSSH). 
+- [add-users.yml](playbooks/add-users.yml) will create user accounts on all hosts in the inventory, and install an SSH authorized key.
+- [remove-users.yml](playbooks/remove-users.yml) will remove user accounts on all hosts in the inventory.
+
+An example execution of the user playbooks is:
+
+- `ansible-playbook playbooks/add-users.yml --extra-vars=users='[{"name":"bob","group":"cluster_admin","is_admin":true,"key":"/home/myuser/bob.pub"}]'`
+- `ansible-playbook playbooks/remove-users.yml --extra-vars=users='[{"name":"bob"}]'`
 
 Note: Be careful with `playbooks/lock-down-sshd.yml`! It will change the SSH port, prevent logins as root and other things. 
 Make sure you understand what it does, and that you don't accidentally lock yourself out of the system. 

--- a/playbooks/add-users.yml
+++ b/playbooks/add-users.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  tasks:
+    - name: Add users
+      include_role:
+        name: add-user
+      with_items: "{{ users }}"

--- a/playbooks/remove-users.yml
+++ b/playbooks/remove-users.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  tasks:
+    - name: Remove users
+      include_role:
+        name: remove-user
+      with_items: "{{ users }}"

--- a/playbooks/set-passwords.yml
+++ b/playbooks/set-passwords.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  tasks:
+    - name: Set passwords
+      include_role:
+        name: set-password
+      with_items: "{{ users }}"

--- a/roles/add-user/tasks/main.yml
+++ b/roles/add-user/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Creates group for user
+  group:
+    name: "{{ item.group }}"
+
+- name: Creates user
+  user:
+    name: "{{ item.name }}"
+    group: "{{ item.group }}"
+
+- name: Add user to wheel group
+  user:
+    name: "{{ item.name }}"
+    append: yes
+    groups: wheel
+  when:
+    - item.is_admin | bool
+
+- name: Add SSH key to authorized keys
+  authorized_key:
+    user: "{{ item.name }}"
+    key: "{{ lookup('file', item.key) }}"

--- a/roles/remove-user/tasks/main.yml
+++ b/roles/remove-user/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Remove user
+  user:
+    name: "{{ item.name }}"
+    state: absent
+    remove: yes

--- a/roles/set-password/tasks/main.yml
+++ b/roles/set-password/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Set password for user
+  user:
+    name: "{{ item.name }}"
+    password: "{{ item.password | password_hash('sha512') }}"


### PR DESCRIPTION
Adds two playbooks, for allowing us to easily set up SSH users with key-based access.

Changes
====
1. Adds playbook to add users.
2. Adds playbook to remove users.

Testing
====
1. Create `ansible.cfg` in the vagrant-playground directory.
2. Set up vagrant machine with `vagrant up`.
3. `vagrant ssh node1` and note the IP address, then exit.
4. Run add playbook via `./local-play.sh ../playbooks/add-users.yml --extra-vars=users='[{"name":"bob","group":"cluster_admin","is_admin":true,"key":"/home/stephen/.ssh/id_rsa.pub"}]`
4. SSH into machine directly via `ssh bob@ip-address`.
5. Confirm user is member of cluster_admin group and wheel with `id`.
6. Run password playbook via `./local-play.sh ../playbooks/set-passwords.yml --extra-vars=users='[{"name":"bob","password":"secretSauce1"}]`
7. Confirm password is set via `sudo ls /usr/sbin`
6. Run remove playbook via `./local-play.sh ../playbooks/remove-users.yml --extra-vars=users='[{"name":"bob"}]`
7. Confirm you can no longer SSH into node1 with the bob user.
