### PR TITLE
Prepare for openshift installation.

### DIFF
--- a/playbooks/add-passwordless-sudo.yml
+++ b/playbooks/add-passwordless-sudo.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  tasks:
+    - name: Add passwordless sudo
+      include_role:
+        name: passwordless-sudo
+      with_items: "{{ users }}"

--- a/playbooks/os-update.yml
+++ b/playbooks/os-update.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - os-update

--- a/roles/passwordless-sudo/tasks/main.yml
+++ b/roles/passwordless-sudo/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Adding passwordless sudo access
+  template:
+    src: sudo.j2
+    dest: "/etc/sudoers.d/{{ item.name }}"

--- a/roles/passwordless-sudo/templates/sudo.j2
+++ b/roles/passwordless-sudo/templates/sudo.j2
@@ -1,0 +1,1 @@
+{{ item.name }} ALL=(ALL) NOPASSWD:ALL

--- a/roles/prepare-openshift/tasks/main.yml
+++ b/roles/prepare-openshift/tasks/main.yml
@@ -50,3 +50,4 @@
   systemd:
     name: docker
     state: started
+    enabled: yes

--- a/roles/secure-sshd/defaults/main.yml
+++ b/roles/secure-sshd/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # Defaults for secure-sshd
- sshd_port: 2222
+ sshd_port: 22555

--- a/roles/secure-sshd/tasks/main.yml
+++ b/roles/secure-sshd/tasks/main.yml
@@ -31,14 +31,26 @@
     regexp: '^Port \d+'
     line: 'Port {{ sshd_port }}'
 
-- name: Open new SSH port
-  firewalld:
-    port: '{{ sshd_port }}/tcp'
-    permanent: true
-    state: enabled
-    
+- name: Allow SSHD to listen on tcp port
+  seport:
+    ports: '{{ sshd_port }}'
+    proto: tcp
+    setype: ssh_port_t
+    state: present
+
+- name: Install FirewallD
+  yum:
+    name: firewalld
+    state: latest
+
 - name: Enable & start FirewallD
   systemd:
     name: firewalld
     state: started
     enabled: yes
+
+- name: Open new SSH port
+  firewalld:
+    port: '{{ sshd_port }}/tcp'
+    permanent: true
+    state: enabled


### PR DESCRIPTION
This PR contains a few fixes and extra utilities I was writing while preparing DNS for openshift installation. All playbooks affected here were tested on the dev-cluster machines successfully.

I broke oc-dev-ansible with a bug in the secure-sshd playbook. Will re-provision that and get it working tomorrow.

Changes
====
1. Fix SELinux bug in securing SSHD
2. Fix the fact docker is not enabled.
3. Adds passwordless-sudo playbook for ansible user.
4. Adds os-update playbook to allow us to install package updates.

Testing
====
1. Create ansible.cfg in the vagrant-playground directory.
2. Set up vagrant machine with vagrant up.
3. vagrant ssh node1 and note the IP address, then exit.
4. Run add playbook via `./local-play.sh ../playbooks/add-users.yml --extra-vars=users='[{"name":"bob","group":"cluster_admin","is_admin":true,"key":"/home/stephen/.ssh/id_rsa.pub"}]`
5. Run passwordless-sudo playbook via `./local-play.sh ../playbooks/passwordless-sudo.yml --extra-vars=users='[{"name":"bob"}]`
6. SSH into machine directly via `ssh bob@ip-address`
7. Confirm passwordless sudo is set via `sudo ls /usr/sbin`
8. Run os-update playbook via `./local-play.sh ../playbooks/os-update.yml`
9. Confirm no new updates installed, due to updates installed via prep-server.yaml on provisioning.

