### PR TITLE
SCAUT-392: Apply Windows updates during os update playbook.

### DIFF
--- a/roles/os-update/tasks/main.yml
+++ b/roles/os-update/tasks/main.yml
@@ -11,5 +11,7 @@
       - SecurityUpdates
       - CriticalUpdates
       - UpdateRollups
+      - Updates
+      - DefinitionUpdates
     reboot: yes
   when: ansible_os_family == 'Windows'

--- a/roles/os-update/tasks/main.yml
+++ b/roles/os-update/tasks/main.yml
@@ -1,5 +1,15 @@
 ---
-- name: Upgrade all packages
+- name: Upgrade all CentOS packages
   yum:
     name: "*"
     state: latest
+  when: ansible_distribution == 'CentOS'
+
+- name: Apply Windows updates
+  win_updates:
+    category_names:
+      - SecurityUpdates
+      - CriticalUpdates
+      - UpdateRollups
+    reboot: yes
+  when: ansible_os_family == 'Windows'


### PR DESCRIPTION
Applies windows updates as part of our OS update playbook. Supports having mixed inventories of both Linux and Windows.

Changes
====
1. Applies windows updates as part of our OS update playbook. Supports having mixed inventories of both Linux and Windows.

Testing
====
1. From ansible-bastion or a suitablt set up ansible environment, run the playbook `ansible-playbook -i inventory playbooks/os-update.yaml`
